### PR TITLE
Adds option for browserMatchAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ await createConfig({
   scopes: ["openid", "profile", "offline_access"],
   requireHardwareBackedKeyStore: true,
   androidChromeTabColor: "#FF00AA",
+  browserMatchAll: true,
   httpConnectionTimeout: 15,
   httpReadTimeout: 10,
 });

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ This method will create a configured client on the native modules. Resolves `tru
 
 **Note**: `androidChromeTabColor` is an optional field in config, and is used only by Android for the Chrome Custom Tabs color for the OIDC flow.
 
+**Note**: `browserMatchAll` is an optional field in config, and is used only by Android to match all Chrome Custom Tabs browsers.
+
 **Note**: `httpConnectionTimeout` and `httpReadTimeout` are optional fields in config. These are used for HTTP requests performed by the SDK. Timeouts are in seconds.
 
 ```javascript

--- a/android/src/main/java/com/oktareactnative/OktaSdkBridgeModule.java
+++ b/android/src/main/java/com/oktareactnative/OktaSdkBridgeModule.java
@@ -75,6 +75,7 @@ public class OktaSdkBridgeModule extends ReactContextBaseJavaModule implements A
             String userAgentTemplate,
             Boolean requireHardwareBackedKeyStore,
             String androidChromeTabColor,
+            Boolean browserMatchAll,
             ReadableMap timeouts,
             Promise promise
     ) {
@@ -107,6 +108,10 @@ public class OktaSdkBridgeModule extends ReactContextBaseJavaModule implements A
                     // The color wasn't in the right format.
                     promise.reject(OktaSdkError.OKTA_OIDC_ERROR.getErrorCode(), e.getLocalizedMessage(), e);
                 }
+            }
+
+            if (browserMatchAll != null && browserMatchAll) {
+                webAuthBuilder.browserMatchAll(true);
             }
 
             this.webClient = webAuthBuilder.create();

--- a/android/src/main/java/com/oktareactnative/OktaSdkBridgeModule.java
+++ b/android/src/main/java/com/oktareactnative/OktaSdkBridgeModule.java
@@ -75,8 +75,8 @@ public class OktaSdkBridgeModule extends ReactContextBaseJavaModule implements A
             String userAgentTemplate,
             Boolean requireHardwareBackedKeyStore,
             String androidChromeTabColor,
-            Boolean browserMatchAll,
             ReadableMap timeouts,
+            Boolean browserMatchAll,
             Promise promise
     ) {
 

--- a/index.js
+++ b/index.js
@@ -45,9 +45,9 @@ export const createConfig = async({
   scopes,
   requireHardwareBackedKeyStore,
   androidChromeTabColor,
-  browserMatchAll,
   httpConnectionTimeout,
   httpReadTimeout,
+  browserMatchAll,
 }) => {
 
   assertIssuer(discoveryUri);
@@ -90,8 +90,8 @@ export const createConfig = async({
     userAgentTemplate,
     requireHardwareBackedKeyStore,
     androidChromeTabColor,
-    browserMatchAll,
     timeouts,
+    browserMatchAll,
   );
 }; 
 

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ export const createConfig = async({
   scopes,
   requireHardwareBackedKeyStore,
   androidChromeTabColor,
+  browserMatchAll,
   httpConnectionTimeout,
   httpReadTimeout,
 }) => {
@@ -89,6 +90,7 @@ export const createConfig = async({
     userAgentTemplate,
     requireHardwareBackedKeyStore,
     androidChromeTabColor,
+    browserMatchAll,
     timeouts,
   );
 }; 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -133,6 +133,7 @@ describe('OktaReactNative', () => {
         config.requireHardwareBackedKeyStore,
         undefined,
         {},
+        undefined,
       );
     });
 
@@ -153,6 +154,7 @@ describe('OktaReactNative', () => {
         config.requireHardwareBackedKeyStore,
         '#FF00AA',
         {},
+        undefined,
       );
     });
     
@@ -171,8 +173,9 @@ describe('OktaReactNative', () => {
         config.scopes,
         `@okta/okta-react-native/${version} $UPSTREAM_SDK react-native/${version} android/1.0.0`,
         config.requireHardwareBackedKeyStore,
-        true,
+        undefined,
         {},
+        true,
       );
     });
 
@@ -192,7 +195,8 @@ describe('OktaReactNative', () => {
         `@okta/okta-react-native/${version} $UPSTREAM_SDK react-native/${version} android/1.0.0`,
         config.requireHardwareBackedKeyStore,
         undefined,
-        { httpConnectionTimeout: 12, httpReadTimeout: 34 }
+        { httpConnectionTimeout: 12, httpReadTimeout: 34 },
+        undefined,
       );
     });
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -155,6 +155,26 @@ describe('OktaReactNative', () => {
         {},
       );
     });
+    
+    it('passes in correct parameters on android device with browserMatchAll', () => {
+      Platform.OS = 'android';
+      Platform.Version = '1.0.0';
+
+      const configWithColor = Object.assign({}, config, { browserMatchAll: true });
+      createConfig(configWithColor);
+      expect(mockCreateConfig).toHaveBeenCalledTimes(1);
+      expect(mockCreateConfig).toHaveBeenLastCalledWith(
+        config.clientId,
+        config.redirectUri,
+        config.endSessionRedirectUri,
+        config.discoveryUri,
+        config.scopes,
+        `@okta/okta-react-native/${version} $UPSTREAM_SDK react-native/${version} android/1.0.0`,
+        config.requireHardwareBackedKeyStore,
+        true,
+        {},
+      );
+    });
 
     it('passes in correct parameters on android device with timeouts', () => {
       Platform.OS = 'android';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-react-native/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently there are scenarios where the library fails to find a compatible browser. If I have chrome and DuckDuckGo installed, DuckDuckGo is the default, the library will fail to launch a browser login.

Issue Number: N/A


## What is the new behavior?
Adds a config option to pass to the underlying okta-oidc-android library authClient option of browserMatchAll(true).


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
OktaSdkBridgeModule.createConfig() takes a new parameter, Boolean browserMatchAll

## Other information
I setup a test and verified 'yarn test' passes, not sure if there are other tests that should be run against it?

## Reviewers

