### PR TITLE
fix: Changes comparison logic for `isAuthenticated` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ await clearTokens();
 
 ### `isAuthenticated`
 
-Returns a promise that resolves to `true` if there is a valid access token or ID token. Otherwise `false`.
+Returns a promise that resolves to `true` if there is a valid Access token and ID token. Otherwise `false`.
 
 ```javascript
 await isAuthenticated();

--- a/ios/OktaSdkBridge.swift
+++ b/ios/OktaSdkBridge.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-Present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
@@ -284,30 +284,26 @@ class OktaSdkBridge: RCTEventEmitter {
     
     @objc(isAuthenticated:promiseRejecter:)
     func isAuthenticated(promiseResolver: @escaping RCTPromiseResolveBlock, promiseRejecter: @escaping RCTPromiseRejectBlock) {
-        
         guard let oidcConfig = config else {
             let error = OktaReactNativeError.notConfigured
             promiseRejecter(error.errorCode, error.errorDescription, error)
             return
         }
         
-        var dic = [
+        var promiseResult = [
             OktaSdkConstant.AUTHENTICATED_KEY: false
         ]
         
         guard let stateManager = OktaOidcStateManager.readFromSecureStorage(for: oidcConfig) else {
-            promiseResolver(dic)
+            promiseResolver(promiseResult)
             return
         }
         
-        if stateManager.idToken != nil || stateManager.accessToken != nil {
-            dic = [
-                OktaSdkConstant.AUTHENTICATED_KEY: true
-            ]
-        }
+        // State Manager returns non expired (fresh) tokens.
+        let areTokensValidAndFresh = stateManager.idToken != nil && stateManager.accessToken != nil
+        promiseResult[OktaSdkConstant.AUTHENTICATED_KEY] = areTokensValidAndFresh
         
-        promiseResolver(dic)
-        return
+        promiseResolver(promiseResult)
     }
     
     @objc(revokeAccessToken:promiseRejecter:)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-react-native/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
Access and ID tokens can have different lifetime. iOS OktaOidc library examines the expiration of these tokens. If the token is expired, null is returned.
Based on that we cannot return isAuthenticated=true because some of the tokens can be expired and refresh is needed. Otherwise, introspect throws an error evaluating null token.

Resolves: OKTA-367974 (#75)


## What is the new behavior?
`isAuthenticated` will be true if both accessToken and idToken are valid

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

Users must upgrade to these change because it fixes a critical bug in functionality.


## Other information
Aligned with [React functionality](https://github.com/okta/okta-react/blob/969d2bc65041cbcc4c24e65439c0dd4163f341bd/CHANGELOG.md#breaking-changes), [JS auth functionality](https://github.com/okta/okta-auth-js/blob/1f89502339605f74c579bd067cad0606b7e6190d/lib/AuthStateManager.ts#L163).

No tests for now, need to cover bridges in the near future.

