### PR TITLE
Adds option for browserMatchAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ This method will create a configured client on the native modules. Resolves `tru
 
 **Note**: `androidChromeTabColor` is an optional field in config, and is used only by Android for the Chrome Custom Tabs color for the OIDC flow.
 
+**Note**: `browserMatchAll` is an optional field in config, and is used only by Android to match all Chrome Custom Tabs browsers.
+
 **Note**: `httpConnectionTimeout` and `httpReadTimeout` are optional fields in config. These are used for HTTP requests performed by the SDK. Timeouts are in seconds.
 
 ```javascript
@@ -185,6 +187,7 @@ await createConfig({
   scopes: ["openid", "profile", "offline_access"],
   requireHardwareBackedKeyStore: true,
   androidChromeTabColor: "#FF00AA",
+  browserMatchAll: true,
   httpConnectionTimeout: 15,
   httpReadTimeout: 10,
 });

--- a/android/src/main/java/com/oktareactnative/OktaSdkBridgeModule.java
+++ b/android/src/main/java/com/oktareactnative/OktaSdkBridgeModule.java
@@ -76,6 +76,7 @@ public class OktaSdkBridgeModule extends ReactContextBaseJavaModule implements A
             Boolean requireHardwareBackedKeyStore,
             String androidChromeTabColor,
             ReadableMap timeouts,
+            Boolean browserMatchAll,
             Promise promise
     ) {
 
@@ -107,6 +108,10 @@ public class OktaSdkBridgeModule extends ReactContextBaseJavaModule implements A
                     // The color wasn't in the right format.
                     promise.reject(OktaSdkError.OKTA_OIDC_ERROR.getErrorCode(), e.getLocalizedMessage(), e);
                 }
+            }
+
+            if (browserMatchAll != null && browserMatchAll) {
+                webAuthBuilder.browserMatchAll(true);
             }
 
             this.webClient = webAuthBuilder.create();

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ export const createConfig = async({
   androidChromeTabColor,
   httpConnectionTimeout,
   httpReadTimeout,
+  browserMatchAll,
 }) => {
 
   assertIssuer(discoveryUri);
@@ -90,6 +91,7 @@ export const createConfig = async({
     requireHardwareBackedKeyStore,
     androidChromeTabColor,
     timeouts,
+    browserMatchAll,
   );
 }; 
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -135,6 +135,7 @@ describe('OktaReactNative', () => {
         config.requireHardwareBackedKeyStore,
         undefined,
         {},
+        undefined,
       );
     });
 
@@ -155,6 +156,28 @@ describe('OktaReactNative', () => {
         config.requireHardwareBackedKeyStore,
         '#FF00AA',
         {},
+        undefined,
+      );
+    });
+    
+    it('passes in correct parameters on android device with browserMatchAll', () => {
+      Platform.OS = 'android';
+      Platform.Version = '1.0.0';
+
+      const configWithColor = Object.assign({}, config, { browserMatchAll: true });
+      createConfig(configWithColor);
+      expect(mockCreateConfig).toHaveBeenCalledTimes(1);
+      expect(mockCreateConfig).toHaveBeenLastCalledWith(
+        config.clientId,
+        config.redirectUri,
+        config.endSessionRedirectUri,
+        config.discoveryUri,
+        config.scopes,
+        `@okta/okta-react-native/${version} $UPSTREAM_SDK react-native/${version} android/1.0.0`,
+        config.requireHardwareBackedKeyStore,
+        undefined,
+        {},
+        true,
       );
     });
 
@@ -174,7 +197,8 @@ describe('OktaReactNative', () => {
         `@okta/okta-react-native/${version} $UPSTREAM_SDK react-native/${version} android/1.0.0`,
         config.requireHardwareBackedKeyStore,
         undefined,
-        { httpConnectionTimeout: 12, httpReadTimeout: 34 }
+        { httpConnectionTimeout: 12, httpReadTimeout: 34 },
+        undefined,
       );
     });
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our [guidelines](/okta/okta-react-native/blob/master/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently there are scenarios where the library fails to find a compatible browser. If I have chrome and DuckDuckGo installed, DuckDuckGo is the default, the library will fail to launch a browser login.
OKTA-370636

Issue Number: N/A


## What is the new behavior?
Adds a config option to pass to the underlying okta-oidc-android library authClient option of browserMatchAll(true).

## Does this PR introduce a breaking change?
- [X] Yes
- [ ] No

OktaSdkBridgeModule.createConfig() takes a new parameter, Boolean browserMatchAll

## Reviewers

