### PR TITLE
fix: Adds types/index.d.ts into files array

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "index.js",
+    "types/index.d.ts",
     "android",
     "ios",
     "LICENSE",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const NPM_DIR = `dist`;
 const FILES_TO_COPY = [
   'index.js',
+  'types/index.d.ts',
   'android',
   'ios',
   'LICENSE',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-react-native/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
> In the package.json, the index.d.ts is not included in the files array so it is not present when installing the library, henceforth typescript is not supported yet.

Issue Number: #21 


## What is the new behavior?
Added index.d.ts visible in the module.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No