### PR TITLE
fix: Adds Swift version to podspec

### DIFF
--- a/OktaSdkBridgeReactNative.podspec
+++ b/OktaSdkBridgeReactNative.podspec
@@ -13,7 +13,8 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platform     = :ios, "11.0"
+  s.platform     = :ios, '11.0'
+  s.swift_version = '5.0'
 
   s.source          = source
   s.source_files  = 'ios/**/*.{h,m,swift}',  'packages/okta-react-native/ios/**/*.{h,m,swift}'


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-react-native/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
Swift version is not defined in podscpec. The error may be occurred during installation for some users. 
Issue Number: OKTA-371911

## What is the new behavior?
Minimum Swift version is added explicitly.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


