### PR TITLE
fix: Fixes "types" parameter in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.9.2
+
+### Other
+
+- [#91](https://github.com/okta/okta-react-native/pull/91) Fixes "types" parameter in package.json
+
 # 1.9.1
 
 ### Other

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "@okta/okta-react-native",
   "title": "React Native Okta Sdk Bridge",
   "version": "1.9.1",
-  "types": "types",
+  "types": "types/index.d.ts",
   "description": "Okta OIDC for React Native",
   "main": "dist/index.js",
   "podname": "OktaSdkBridgeReactNative",


### PR DESCRIPTION
Note for the future: To check whether a file is visible in a package, make `yarn pack` and then `yarn add {path-to-archive}`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-react-native/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
index.d.ts is not packed in a package.

Issue Number: #21 


## What is the new behavior?
Added index.d.ts as "types" parameter in package.json

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No