### PR TITLE
Use maven-publish

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,8 +23,10 @@ buildscript {
     }
 }
 
-apply plugin: 'com.android.library'
-apply plugin: 'maven'
+plugins {
+    id('com.android.library')
+    id('maven-publish')
+}
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -108,7 +110,7 @@ afterEvaluate { project ->
     }
 
     task androidSourcesJar(type: Jar) {
-        classifier = 'sources'
+        archiveClassifier = 'sources'
         from android.sourceSets.main.java.srcDirs
         include '**/*.java'
     }
@@ -125,13 +127,11 @@ afterEvaluate { project ->
         archives androidJavadocJar
     }
 
-    task installArchives(type: Upload) {
-        configuration = configurations.archives
-        repositories.mavenDeployer {
-            // Deploy to react-native-event-bridge/maven, ready to publish to npm
-            repository url: "file://${projectDir}/../android/maven"
-
-            configureReactNativePom pom
+    publishing {
+        publications {
+            maven(MavenPublication) {
+                artifact androidSourcesJar
+            }
         }
     }
 }


### PR DESCRIPTION
> Use maven-publish instead of maven to support React Native 0.67.1
> maven has been deprecated since gradle 6.0 and was removed in gradle 7.0
> Resolves #260

https://github.com/okta/okta-react-native/pull/261