### PR TITLE
Updates iOS OIDC to 3.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.5.1
+
+### Bug Fix
+- Updates iOS OIDC dependency
+
 # 2.5.0
 
 ### Bug Fix

--- a/OktaSdkBridgeReactNative.podspec
+++ b/OktaSdkBridgeReactNative.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.source_files  = 'ios/OktaSdkBridge/**/*.{h,m,swift}',  'packages/okta-react-native/ios/OktaSdkBridge/**/*.{h,m,swift}'
 
   s.dependency 'React'
-  s.dependency 'OktaOidc', '3.11.0'
+  s.dependency 'OktaOidc', '3.11.2'
 end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -11,11 +11,11 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.68.3)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - OktaOidc (3.11.0):
-    - OktaOidc/AppAuth (= 3.11.0)
-    - OktaOidc/Okta (= 3.11.0)
-  - OktaOidc/AppAuth (3.11.0)
-  - OktaOidc/Okta (3.11.0):
+  - OktaOidc (3.11.2):
+    - OktaOidc/AppAuth (= 3.11.2)
+    - OktaOidc/Okta (= 3.11.2)
+  - OktaOidc/AppAuth (3.11.2)
+  - OktaOidc/Okta (3.11.2):
     - OktaOidc/AppAuth
   - RCT-Folly (2021.06.28.00-v2):
     - boost
@@ -398,13 +398,13 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: 34f7420274737b6fcf2e2d9fd42641e66b4436a3
   FBReactNativeSpec: 68c23fb2cea9393190e0815b673d742fa33d2dab
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
-  OktaOidc: 7a6a9a827722b26fded69c9715e606f5abc3a3a7
-  RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a
+  glog: 476ee3e89abb49e07f822b48323c51c57124b572
+  OktaOidc: 15fb3d494103d4f07ba8a523b3347d02c4d30486
+  RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
   RCTRequired: b8caca023d386d43740dfb94c2cf68f695fa5e77
   RCTTypeSafety: ec44ea1d6ad1e5cd6447b22159ff40c2ebbd23b1
   React: 9f8c8afb9a9d61b7a1b01a1c6fb7f0d4f902988f


### PR DESCRIPTION
Upgrades the iOS OIDC dependency to version 3.11.2. This version prevents a compilation error that was previously present when building with Xcode 14.

This change allows apps using `okta-react-native` to be built using Xcode 14.

See details on iOS IODC 3.11.2 release [here](https://github.com/okta/okta-oidc-ios/releases/tag/3.11.2).

Closes #320 

