### PR TITLE
Fix CustomLogin logout functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,6 @@ await signOut();
 
 ```javascript
 await revokeAccessToken(); // optional
-await revokeIdToken(); // optional
 await clearTokens();
 ```
 

--- a/e2e/android/app/src/androidTest/java/com/e2eoktareactnative/login/CustomLoginTest.kt
+++ b/e2e/android/app/src/androidTest/java/com/e2eoktareactnative/login/CustomLoginTest.kt
@@ -48,4 +48,13 @@ internal class CustomLoginTest {
             .assertHasError("Sign in was not authorized")
             .pressAlertOkButton()
     }
+
+    @Test
+    fun testCustomLoginLogout() {
+        LoginPage().customLogin()
+            .username(testUsername)
+            .password(testPassword)
+            .login()
+            .logout()
+    }
 }

--- a/e2e/pages/ProfilePage.js
+++ b/e2e/pages/ProfilePage.js
@@ -85,7 +85,7 @@ export default class ProfilePage extends React.Component {
 
   render() {
     const userName = this.state.userInfo.name;
-    const preferredUserName = this.state.idToken.preferred_username;
+    const preferredUserName = this.state.userInfo.preferred_username;
     return (
       <View style={styles.container}>
         {userName && <Text testID="user_name">User: {userName}</Text>}

--- a/e2e/pages/ProfilePage.js
+++ b/e2e/pages/ProfilePage.js
@@ -75,7 +75,7 @@ export default class ProfilePage extends React.Component {
       });
     }
 
-    Promise.all([revokeAccessToken(), revokeIdToken(), clearTokens()])
+    Promise.all([revokeAccessToken(), clearTokens()])
       .then(() => {
         this.props.navigation.popToTop();
       }).catch(error => {


### PR DESCRIPTION
This PR fixes revokeToken when using custom login on Android. Note that this PR also makes changes to suggest not calling revokeAccessToken and revokeIdToken at the same time since revoking one revokes the other.