### PR TITLE
Fix createConfig on iOS and error handling on Android

### DIFF
--- a/android/src/main/java/com/oktareactnative/OktaSdkBridgeModule.java
+++ b/android/src/main/java/com/oktareactnative/OktaSdkBridgeModule.java
@@ -130,7 +130,7 @@ public class OktaSdkBridgeModule extends ReactContextBaseJavaModule implements A
                     webAuthBuilder.withTabColor(Color.parseColor(androidChromeTabColor));
                 } catch (IllegalArgumentException e) {
                     // The color wasn't in the right format.
-                    errorCallback.invoke(OktaSdkError.OKTA_OIDC_ERROR.getErrorCode(), e.getLocalizedMessage(), e);
+                    errorCallback.invoke(OktaSdkError.OKTA_OIDC_ERROR.getErrorCode(), e.getLocalizedMessage(), getStackTraceString(e));
                 }
             }
 
@@ -152,7 +152,7 @@ public class OktaSdkBridgeModule extends ReactContextBaseJavaModule implements A
                 sessionClient = this.authClient.getSessionClient();
             }
         } catch (Exception e) {
-            errorCallback.invoke(OktaSdkError.OKTA_OIDC_ERROR.getErrorCode(), e.getLocalizedMessage(), e);
+            errorCallback.invoke(OktaSdkError.OKTA_OIDC_ERROR.getErrorCode(), e.getLocalizedMessage(), getStackTraceString(e));
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -54,7 +54,8 @@ class OktaStatusError extends Error {
   }
 }
 
-export const createConfig = async({
+/* eslint-disable max-params */
+export function createConfigWithCallbacks(
   issuer,
   clientId,
   redirectUri, 
@@ -66,9 +67,10 @@ export const createConfig = async({
   httpConnectionTimeout,
   httpReadTimeout,
   browserMatchAll = false,
-  oktaAuthConfig = {}
-}) => {
-
+  oktaAuthConfig = {},
+  onSuccess,
+  onError
+) {
   assertIssuer(discoveryUri);
   assertClientId(clientId);
   assertRedirectUri(redirectUri);
@@ -112,12 +114,8 @@ export const createConfig = async({
       scopes,
       userAgentTemplate,
       httpConnectionTimeout,
-      successResponse => {
-        return successResponse;
-      },
-      errorResponse => {
-        return errorResponse;
-      }
+      onSuccess,
+      onError
     );
   } else {
 
@@ -137,14 +135,49 @@ export const createConfig = async({
       androidChromeTabColor,
       timeouts,
       browserMatchAll,
-      successResponse => {
-        return successResponse;
-      },
-      errorResponse => {
-        return errorResponse;
-      }
+      onSuccess,
+      onError
     );
   }
+}
+/* eslint-enable max-params */
+
+export const createConfig = async({
+  issuer,
+  clientId,
+  redirectUri, 
+  endSessionRedirectUri, 
+  discoveryUri,
+  scopes,
+  requireHardwareBackedKeyStore,
+  androidChromeTabColor,
+  httpConnectionTimeout,
+  httpReadTimeout,
+  browserMatchAll = false,
+  oktaAuthConfig = {}
+}) => {
+  return await new Promise((resolve, reject) => {
+    createConfigWithCallbacks(
+      issuer,
+      clientId,
+      redirectUri, 
+      endSessionRedirectUri, 
+      discoveryUri,
+      scopes,
+      requireHardwareBackedKeyStore,
+      androidChromeTabColor,
+      httpConnectionTimeout,
+      httpReadTimeout,
+      browserMatchAll,
+      oktaAuthConfig,
+      successResponse => {
+        resolve(successResponse);
+      },
+      (errorCode, localizedMessage, stackTrace) => {
+        reject([errorCode, localizedMessage, stackTrace]);
+      }
+    );
+  });
 }; 
 
 export const getAuthClient = () => {

--- a/ios/OktaSdkBridge/OktaSdkBridge.swift
+++ b/ios/OktaSdkBridge/OktaSdkBridge.swift
@@ -108,7 +108,7 @@ class OktaSdkBridge: RCTEventEmitter {
             
             successCallback([true])
         } catch let error {
-            errorCallback([OktaReactNativeError.oktaOidcError.errorCode, error.localizedDescription, error])
+            errorCallback([OktaReactNativeError.oktaOidcError.errorCode!, error.localizedDescription, Thread.callStackSymbols])
         }
     }
     

--- a/ios/OktaSdkBridge/ReactNativeOktaSdkBridge.m
+++ b/ios/OktaSdkBridge/ReactNativeOktaSdkBridge.m
@@ -23,8 +23,8 @@ RCT_EXTERN_METHOD(
   scopes:(NSString *)scopes 
   userAgentTemplate:(NSString *)userAgentTemplate
   requestTimeout:(NSInteger)requestTimeout
-  promiseResolver:(RCTPromiseResolveBlock *)promiseResolver 
-  promiseRejecter:(RCTPromiseRejectBlock *)promiseRejecter
+  successCallback:(RCTResponseSenderBlock *)successCallback
+  errorCallback:(RCTResponseSenderBlock *)errorCallback
 )
 
 RCT_EXTERN_METHOD(

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -132,7 +132,10 @@ describe('OktaReactNative', () => {
           mockConfig2: 'mock config 2'
         }
       };
-      await createConfig(config);
+      let promise = createConfig(config);
+      let onSuccess = mockCreateConfig.mock.calls[0][7];
+      onSuccess(true);
+      await promise;
       expect(OktaAuth).toHaveBeenCalledWith({
         issuer: 'https://dummy_issuer',
         clientId: 'dummy_client_id',
@@ -254,7 +257,10 @@ describe('OktaReactNative', () => {
     });
 
     it('adds an environment to oktaAuth\'s _oktaUserAgent', async () => {
-      await createConfig(config);
+      let promise = createConfig(config);
+      let onSuccess = mockCreateConfig.mock.calls[0][10];
+      onSuccess(true);
+      await promise;
 
       let mockOktaUserAgentAddEnvironment = getAuthClient()._oktaUserAgent.addEnvironment;
       expect(mockOktaUserAgentAddEnvironment).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
This fixes createConfig errors on iOS introduced in 2.11.0. There are also some changes on Android side to avoid a crash in case of an exception.