### PR TITLE
Update parameters for signInWithBrowser

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -90,6 +90,8 @@ export namespace Okta {
   interface BrowserOptions {
     idp?: string;
     noSSO?: boolean;
+    login_hint?: string
+    prompt?: string
   }
 
   interface StringAnyMap {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -43,6 +43,10 @@ expectType<Promise<Okta.AuthenticationResponse>>(OktaSDK.signInWithBrowser({ idp
 
 expectType<Promise<Okta.AuthenticationResponse>>(OktaSDK.signInWithBrowser({ noSSO: true }));
 
+expectType<Promise<Okta.AuthenticationResponse>>(OktaSDK.signInWithBrowser({ login_hint: 'some@email.com' }));
+
+expectType<Promise<Okta.AuthenticationResponse>>(OktaSDK.signInWithBrowser({ prompt: 'Prompt' }));
+
 expectType<Promise<Okta.AuthenticationResponse>>(OktaSDK.authenticate({ sessionToken: 'sessionToken' }));
 
 expectType<Promise<{ resolve_type: string; }>>(OktaSDK.signOut());


### PR DESCRIPTION
After working with `signInWithBrowser` my team discovered that the method had insufficient type definitions. This PR updates the definitions