### PR TITLE
Remove deprecated @okta/configuration-validation and integrate essential functions

### DIFF
--- a/.github/workflows/okta-react-native.yml
+++ b/.github/workflows/okta-react-native.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Execute snyk.sh
         run: bash ./scripts/snyk.sh
     iOSUnitTests:
-      runs-on: macos-12
+      runs-on: macos-13
       steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -43,7 +43,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./ios/Pods
-          key: pods-${{ hashFiles('./ios/Podfile.lock') }}          
+          key: pods-${{ hashFiles('./ios/Podfile.lock') }}
       - name: Preparation before iOS Build
         run: |
           pod install --project-directory=ios --repo-update
@@ -56,19 +56,19 @@ jobs:
           -destination "platform=iOS Simulator,OS=latest,name=iPhone 14" \
           clean test | xcpretty
     # iOSUITests:
-    #   runs-on: macos-12
+    #   runs-on: macos-13
     #   steps:
     #   - uses: actions/checkout@v3
-    #   - name: Cache ./node_modules    
+    #   - name: Cache ./node_modules
     #     uses: ./.github/workflows/composite/configure-node
-    #     with:  
+    #     with:
     #       node-path: ./node_modules
     #       lock-hash: ${{ hashFiles('yarn.lock') }}
     #   - name: Build okta-react-native package
-    #     run: yarn build 
+    #     run: yarn build
     #   - name: Cache e2e/node_modules
     #     uses: ./.github/workflows/composite/configure-node
-    #     with:  
+    #     with:
     #       node-path: ./e2e/node_modules
     #       lock-hash: ${{ hashFiles('./e2e/yarn.lock') }}
     #       install-path: ./e2e
@@ -88,11 +88,11 @@ jobs:
     #       cd ../..
     #       echo -e "CLIENT_ID=${{ secrets.CLIENT_ID }}\nISSUER=${{ secrets.ISSUER }}\nREDIRECT_URI=${{ secrets.REDIRECT_URI }}\nLOGOUT_REDIRECT_URI=${{secrets.LOGOUT_REDIRECT_URI}}" > e2e/.env
     #   - name: iOS
-    #     env: 
+    #     env:
     #       OKTA_USERNAME: ${{ secrets.OKTA_USERNAME }}
     #       OKTA_PASSWORD: ${{ secrets.OKTA_PASSWORD }}
-    #     run: | 
-    #       set -o pipefail 
+    #     run: |
+    #       set -o pipefail
     #       xcodebuild \
     #       -workspace e2e/ios/E2EOktaReactNative.xcworkspace \
     #       -scheme E2EOktaReactNative \
@@ -116,7 +116,7 @@ jobs:
 
     #   - name: Configure node_modules
     #     uses: ./.github/workflows/composite/configure-node
-    #     with:  
+    #     with:
     #       node-path: ./node_modules
     #       lock-hash: ${{ hashFiles('yarn.lock') }}
 
@@ -125,7 +125,7 @@ jobs:
 
     #   - name: Configure e2e/node_modules
     #     uses: ./.github/workflows/composite/configure-node
-    #     with:  
+    #     with:
     #       node-path: ./e2e/node_modules
     #       lock-hash: ${{ hashFiles('./e2e/yarn.lock') }}
     #       install-path: ./e2e

--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@
  */
 
 import { NativeModules, Platform, NativeEventEmitter } from 'react-native';
-import { assertIssuer, assertClientId, assertRedirectUri } from '@okta/configuration-validation';
 import { OktaAuth } from '@okta/okta-auth-js';
 import Url from 'url-parse';
 import { version, peerDependencies } from './package.json';
@@ -54,12 +53,66 @@ class OktaStatusError extends Error {
   }
 }
 
+class ConfigurationValidationError extends Error {}
+const findDomainURL = 'https://bit.ly/finding-okta-domain';
+const findAppCredentialsURL = 'https://bit.ly/finding-okta-app-credentials';
+const copyCredentialsMessage = 'You can copy it from the Okta Developer Console ' +
+  'in the details for the Application you created. ' +
+  `Follow these instructions to find it: ${findAppCredentialsURL}`;
+
+const isHttps = new RegExp('^https://');
+const hasDomainAdmin = /-admin.(okta|oktapreview|okta-emea).com/;
+
+function assertIssuer(issuer, testing = {}){
+  const copyMessage = 'You can copy your domain from the Okta Developer ' +
+    'Console. Follow these instructions to find it: ' + findDomainURL;
+
+  if (testing.disableHttpsCheck) {
+    const httpsWarning = 'Warning: HTTPS check is disabled. ' +
+      'This allows for insecure configurations and is NOT recommended for production use.';
+    /* eslint-disable-next-line no-console */
+    console.warn(httpsWarning);
+  }
+
+  if (!issuer) {
+    throw new ConfigurationValidationError('Your Okta URL is missing. ' + copyMessage);
+  } else if (!testing.disableHttpsCheck && !issuer.match(isHttps)) {
+    throw new ConfigurationValidationError(
+      'Your Okta URL must start with https. ' +
+      `Current value: ${issuer}. ${copyMessage}`
+    );
+  } else if (issuer.match(/{yourOktaDomain}/)) {
+    throw new ConfigurationValidationError('Replace {yourOktaDomain} with your Okta domain. ' + copyMessage);
+  } else if (issuer.match(hasDomainAdmin)) {
+    throw new ConfigurationValidationError(
+      'Your Okta domain should not contain -admin. ' +
+      `Current value: ${issuer}. ${copyMessage}`
+    );
+  }
+}
+
+function assertClientId(clientId){
+  if (!clientId) {
+    throw new ConfigurationValidationError('Your client ID is missing. ' + copyCredentialsMessage);
+  } else if (clientId.match(/{clientId}/)) {
+    throw new ConfigurationValidationError('Replace {clientId} with the client ID of your Application. ' + copyCredentialsMessage);
+  }
+}
+
+function assertRedirectUri(redirectUri){
+  if (!redirectUri) {
+    throw new ConfigurationValidationError('Your redirect URI is missing.');
+  } else if (redirectUri.match(/{redirectUri}/)) {
+    throw new ConfigurationValidationError('Replace {redirectUri} with the redirect URI of your Application.');
+  }
+}
+
 /* eslint-disable max-params */
 export function createConfigWithCallbacks(
   issuer,
   clientId,
-  redirectUri, 
-  endSessionRedirectUri, 
+  redirectUri,
+  endSessionRedirectUri,
   discoveryUri,
   scopes,
   requireHardwareBackedKeyStore,
@@ -84,18 +137,18 @@ export function createConfigWithCallbacks(
       token: {
         storageProvider: storageProvider
       }
-    },  
+    },
     issuer: issuer || origin,
     clientId,
     redirectUri,
     scopes
   };
-  
+
   authClient = new OktaAuth(oktaAuthConfig);
 
   const reactNativeVersion = peerDependencies['react-native'];
   const userAgentTemplate = `okta-react-native/${version} $UPSTREAM_SDK react-native/${reactNativeVersion} ${Platform.OS}/${Platform.Version}`;
-  
+
   if (authClient._oktaUserAgent) {
     authClient._oktaUserAgent.addEnvironment(userAgentTemplate.replace('$UPSTREAM_SDK ', ''));
   }
@@ -123,7 +176,7 @@ export function createConfigWithCallbacks(
       httpConnectionTimeout,
       httpReadTimeout,
     };
-      
+
     NativeModules.OktaSdkBridge.createConfig(
       clientId,
       redirectUri,
@@ -145,8 +198,8 @@ export function createConfigWithCallbacks(
 export const createConfig = async({
   issuer,
   clientId,
-  redirectUri, 
-  endSessionRedirectUri, 
+  redirectUri,
+  endSessionRedirectUri,
   discoveryUri,
   scopes,
   requireHardwareBackedKeyStore,
@@ -160,8 +213,8 @@ export const createConfig = async({
     createConfigWithCallbacks(
       issuer,
       clientId,
-      redirectUri, 
-      endSessionRedirectUri, 
+      redirectUri,
+      endSessionRedirectUri,
       discoveryUri,
       scopes,
       requireHardwareBackedKeyStore,
@@ -178,12 +231,12 @@ export const createConfig = async({
       }
     );
   });
-}; 
+};
 
 export const getAuthClient = () => {
   if (!authClient) {
     throw new OktaAuthError(
-      '-100', 
+      '-100',
       'OktaOidc client isn\'t configured, check if you have created a configuration with createConfig'
     );
   }
@@ -198,10 +251,10 @@ export const signIn = async(options) => {
         const { status, sessionToken } = transaction;
         if (status !== 'SUCCESS') {
           throw new OktaStatusError(
-            'Transaction status other than "SUCCESS" has been returned. Check transaction.status and handle accordingly.', 
+            'Transaction status other than "SUCCESS" has been returned. Check transaction.status and handle accordingly.',
             status
           );
-        } 
+        }
 
         return authenticate({ sessionToken });
       })
@@ -222,8 +275,8 @@ export const signIn = async(options) => {
 };
 
 export const signInWithBrowser = async(options = {}) => {
-  if (typeof options.noSSO === 'boolean') { 
-    options.noSSO = options.noSSO.toString(); 
+  if (typeof options.noSSO === 'boolean') {
+    options.noSSO = options.noSSO.toString();
   }
 
   return NativeModules.OktaSdkBridge.signIn(options);
@@ -282,23 +335,23 @@ export const revokeRefreshToken = async() => {
 };
 
 export const introspectAccessToken = async() => {
-  return NativeModules.OktaSdkBridge.introspectAccessToken(); 
+  return NativeModules.OktaSdkBridge.introspectAccessToken();
 };
 
 export const introspectIdToken = async() => {
-  return NativeModules.OktaSdkBridge.introspectIdToken(); 
+  return NativeModules.OktaSdkBridge.introspectIdToken();
 };
 
 export const introspectRefreshToken = async() => {
-  return NativeModules.OktaSdkBridge.introspectRefreshToken(); 
+  return NativeModules.OktaSdkBridge.introspectRefreshToken();
 };
 
 export const refreshTokens = async() => {
-  return NativeModules.OktaSdkBridge.refreshTokens(); 
+  return NativeModules.OktaSdkBridge.refreshTokens();
 };
 
 export const clearTokens = async() => {
-  return NativeModules.OktaSdkBridge.clearTokens(); 
+  return NativeModules.OktaSdkBridge.clearTokens();
 };
 
 export const EventEmitter = new NativeEventEmitter(NativeModules.OktaSdkBridge);

--- a/package.json
+++ b/package.json
@@ -73,8 +73,7 @@
   },
   "dependencies": {
     "@babel/plugin-transform-async-to-generator": "^7.24.7",
-    "@okta/configuration-validation": "^1.1.0",
-    "@okta/okta-auth-js": "7.7.0",
+    "@okta/okta-auth-js": "7.8.1",
     "jscodeshift": "^0.15.2",
     "jwt-decode": "^4.0.0",
     "url-parse": "^1.5.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,14 +1076,6 @@
     pirates "^4.0.6"
     source-map-support "^0.5.16"
 
-"@babel/runtime-corejs3@^7.17.0":
-  version "7.25.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.25.7.tgz#29ca319b1272e9d78faa3f7ee891d0af63c53aa2"
-  integrity sha512-gMmIEhg35sXk9Te5qbGp3W9YKrvLt3HV658/d3odWrHSqT0JeG5OzsJWFHRLiOohRyjRsJc/x03DhJm3i8VJxg==
-  dependencies:
-    core-js-pure "^3.30.2"
-    regenerator-runtime "^0.14.0"
-
 "@babel/runtime@7.22.10":
   version "7.22.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.10.tgz#ae3e9631fd947cb7e3610d3e9d8fef5f76696682"
@@ -1091,7 +1083,7 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.16.0", "@babel/runtime@^7.17.9", "@babel/runtime@^7.25.0", "@babel/runtime@^7.6.2", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.17.9", "@babel/runtime@^7.25.0", "@babel/runtime@^7.8.4":
   version "7.25.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.25.7.tgz#7ffb53c37a8f247c8c4d335e89cdf16a2e0d0fb6"
   integrity sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==
@@ -1496,17 +1488,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@okta/configuration-validation@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@okta/configuration-validation/-/configuration-validation-1.1.0.tgz#722d5d5fe485f741348104731a9ff5571d7f301d"
-  integrity sha512-aKzioChvhU153cT5S++N6nT6MSOx2r55tBhccawaOzyjvrNi9B3UGZQb/CcYq1c9v6bDamAQ/kzexZDwWrkq6Q==
-  dependencies:
-    "@okta/okta-auth-js" "^6.1.0"
-
-"@okta/okta-auth-js@7.7.0":
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-7.7.0.tgz#daac09294316a69d996a33232eb25032d1b85d70"
-  integrity sha512-m+WlI9TJ3J2uHI+W9Uc7zinE4CQLS2JC6AQYPJ0KHxaVE5lwPDLFleapPNfNWzYGr/30GV7oBzJMU+8+UQEsPA==
+"@okta/okta-auth-js@7.8.1":
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-7.8.1.tgz#eb36ac8deb0290f59917ede239fae82d76cc2ab8"
+  integrity sha512-vrsh1QK2NxZQgOQHqIX33ykTsf+X3zcHIzdNjbPbxp1YvTZeyd9oNlcLh1cgp4m0xA/NXoj5xM4no6j3SFtnUw==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@peculiar/webcrypto" "^1.4.0"
@@ -1518,32 +1503,8 @@
     cross-fetch "^3.1.5"
     fast-text-encoding "^1.0.6"
     js-cookie "^3.0.1"
-    jsonpath-plus "^6.0.1"
     node-cache "^5.1.2"
     p-cancelable "^2.0.0"
-    tiny-emitter "1.1.0"
-    webcrypto-shim "^0.1.5"
-    xhr2 "0.1.3"
-
-"@okta/okta-auth-js@^6.1.0":
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-6.9.0.tgz#2b568234f1c2ef203160faa4f4697bb02038ab83"
-  integrity sha512-IAh9mh2iGT4bsGeRMSSGBYoeEJ4f3ABTO+Jf9mYr0MbKgyU+X+7RwYAo/z8JHJ9AW0ynmjERTMOgDJ7/H/N+Dw==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@babel/runtime-corejs3" "^7.17.0"
-    "@peculiar/webcrypto" "^1.4.0"
-    Base64 "1.1.0"
-    atob "^2.1.2"
-    broadcast-channel "~4.17.0"
-    btoa "^1.2.1"
-    core-js "^3.6.5"
-    cross-fetch "^3.1.5"
-    js-cookie "^3.0.1"
-    jsonpath-plus "^6.0.1"
-    node-cache "^5.1.2"
-    p-cancelable "^2.0.0"
-    text-encoding "^0.7.0"
     tiny-emitter "1.1.0"
     webcrypto-shim "^0.1.5"
     xhr2 "0.1.3"
@@ -2682,17 +2643,6 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-broadcast-channel@~4.17.0:
-  version "4.17.0"
-  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.17.0.tgz#599d44674b09a4e2e07af6da5d03b45ca8bffd11"
-  integrity sha512-r2GSQMNgZv7eAsbdsu9xofSjc3J2diCQTPkSuyVhLBfx8fylLCVhi5KheuhuAQBJNd4pxqUyz9U6rvdnt7GZng==
-  dependencies:
-    "@babel/runtime" "^7.16.0"
-    oblivious-set "1.1.1"
-    p-queue "6.6.2"
-    rimraf "3.0.2"
-    unload "2.3.1"
-
 broadcast-channel@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-5.3.0.tgz#9d9e55fb8db2a1dbbe436ae6d51382a354e76fc3"
@@ -3021,11 +2971,6 @@ core-js-compat@^3.38.0, core-js-compat@^3.38.1:
   dependencies:
     browserslist "^4.23.3"
 
-core-js-pure@^3.30.2:
-  version "3.38.1"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.38.1.tgz#e8534062a54b7221344884ba9b52474be495ada3"
-  integrity sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==
-
 core-js@^3.6.5:
   version "3.38.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.38.1.tgz#aa375b79a286a670388a1a363363d53677c0383e"
@@ -3207,11 +3152,6 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
-
-detect-node@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
-  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 diff-sequences@^29.6.3:
   version "29.6.3"
@@ -5053,11 +4993,6 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonpath-plus@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz#9a3e16cedadfab07a3d8dc4e8cd5df4ed8f49c4d"
-  integrity sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw==
-
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz#4766bd05a8e2a11af222becd19e15575e52a853a"
@@ -6483,7 +6418,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@3.0.2, rimraf@^3.0.2:
+rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -6992,11 +6927,6 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
-text-encoding@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.7.0.tgz#f895e836e45990624086601798ea98e8f36ee643"
-  integrity sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==
-
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -7225,14 +7155,6 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
-
-unload@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/unload/-/unload-2.3.1.tgz#9d16862d372a5ce5cb630ad1309c2fd6e35dacfe"
-  integrity sha512-MUZEiDqvAN9AIDRbbBnVYVvfcR6DrjCqeU2YQMmliFZl9uaBUjTkhuDQkBiyAy8ad5bx1TXVbqZ3gg7namsWjA==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    detect-node "2.1.0"
 
 unload@2.4.1:
   version "2.4.1"


### PR DESCRIPTION
This PR removes the deprecated [@okta/configuration-validation](https://github.com/okta/okta-oidc-js) package and integrates the essential functions directly into index.js. 

Additionally, this change resolves a security vulnerability in the `jsonpath-plus` package.

Resolves: #432 