### PR TITLE
Don't follow redirects for OkHttp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.17.0
+- Don't follow redirects for OkHttp. This fixes MFA issues when using classic Okta and session token login.
+
 # 2.16.0
 - Fix vulnerabilities and remove jsonpath-plus. Thanks to [vero1024](https://github.com/vero1024) for contribution in this release!
 

--- a/android/src/main/java/com/oktareactnative/HttpClientImpl.java
+++ b/android/src/main/java/com/oktareactnative/HttpClientImpl.java
@@ -62,6 +62,7 @@ public class HttpClientImpl implements OktaHttpClient {
             sOkHttpClient = new OkHttpClient.Builder()
                     .connectTimeout(connectTimeoutMs, TimeUnit.MILLISECONDS)
                     .readTimeout(readTimeoutMs, TimeUnit.MILLISECONDS)
+                    .followRedirects(false)
                     .build();
         }
         Request.Builder requestBuilder = new Request.Builder().url(uri.toString());


### PR DESCRIPTION
This fixes MFA issues when using classic Okta and session token login. 2.13 and below set this flag, and it was removed when I reimplemented the network layer with OkHttp in this commit: https://github.com/okta/okta-react-native/commit/a62182445804d9d60ad0b9106113df8368119d41

This seemed insignificant at that time, but it turns out to be important for V1 session token MFA flows.