### PR TITLE
Update netty to 4.1.125

### DIFF
--- a/android/forceVersions.gradle
+++ b/android/forceVersions.gradle
@@ -2,9 +2,9 @@ def forceVersions(ConfigurationContainer configurations) {
     configurations.configureEach { configuration ->
         configuration.resolutionStrategy {
             force 'org.bouncycastle:bcprov-jdk18on:1.78.1'
-            force 'io.netty:netty-handler:4.1.124.Final'
-            force 'io.netty:netty-codec-http:4.1.124.Final'
-            force 'io.netty:netty-codec-http2:4.1.124.Final'
+            force 'io.netty:netty-handler:4.1.125.Final'
+            force 'io.netty:netty-codec-http:4.1.125.Final'
+            force 'io.netty:netty-codec-http2:4.1.125.Final'
             force 'com.google.protobuf:protobuf-java:4.29.3'
         }
     }

--- a/e2e/android/forceVersions.gradle
+++ b/e2e/android/forceVersions.gradle
@@ -13,9 +13,9 @@ def forceVersions(ConfigurationContainer configurations) {
             force 'junit:junit:4.13.2'
             force 'commons-io:commons-io:2.15.1'
             force 'commons-codec:commons-codec:1.17.0'
-            force 'io.netty:netty-handler:4.1.124.Final'
-            force 'io.netty:netty-codec-http:4.1.124.Final'
-            force 'io.netty:netty-codec-http2:4.1.124.Final'
+            force 'io.netty:netty-handler:4.1.125.Final'
+            force 'io.netty:netty-codec-http:4.1.125.Final'
+            force 'io.netty:netty-codec-http2:4.1.125.Final'
             force 'com.google.protobuf:protobuf-java:3.25.6'
         }
     }


### PR DESCRIPTION
Fixes: CVE-2025-58056, CVE-2025-58057