### PR TITLE
fix[e2e]: Fixes security vulnerability in node-forge

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -31,7 +31,8 @@
     "tar": "^6.2.1",
     "micromatch": "^4.0.7",
     "braces": "^3.0.3",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
+    "node-forge": "^1.3.3"
   },
   "devDependencies": {
     "@babel/core": "^7.24.6"

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -4352,10 +4352,10 @@ node-fetch@^2.2.0, node-fetch@^2.6.1, node-fetch@^2.7.0:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@^1, node-forge@^1.2.1, node-forge@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
-  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+node-forge@1.3.3, node-forge@^1, node-forge@^1.2.1, node-forge@^1.3.1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.3.tgz#0ad80f6333b3a0045e827ac20b7f735f93716751"
+  integrity sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
fix[e2e]: Fixes security vulnerability in node-forge

Upgrades transitive dependency `node-forge` to ^1.3.3 via `resolutions` to address vulnerability reported

Resolves: #1065302