### PR TITLE
Change `destinationDir` to `destinationDirectory` to make build work with gradle 9.0.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -110,7 +110,7 @@ afterEvaluate { project ->
         def javaCompileTask = variant.javaCompileProvider.get()
 
         task "jar${name}"(type: Jar, dependsOn: javaCompileTask) {
-            from javaCompileTask.destinationDir
+            from javaCompileTask.destinationDirectory
         }
     }
 


### PR DESCRIPTION
fixes #468
